### PR TITLE
Use the .po files to work out which manpage dirs to create

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -214,7 +214,7 @@ install:	all
 		fi
 		$(INSTALL_DIR) $(ROOT)/usr/include/
 		$(INSTALL_DATA) initreq.h $(ROOT)/usr/include/
-		for lang in  '' $(subst ../man/,,$(wildcard ../man/po/??/)); do \
+		for lang in  '' $(patsubst ../man/po/%.po,%,$(wildcard ../man/po/??.po)); do \
 			$(INSTALL_DIR) $(ROOT)$(MANDIR)/man1/$$lang; \
 			$(INSTALL_DIR) $(ROOT)$(MANDIR)/man5/$$lang; \
 			$(INSTALL_DIR) $(ROOT)$(MANDIR)/man8/$$lang; \


### PR DESCRIPTION
In the 3.05 release tarball, installation into an empty prefix (e.g. `make ROOT=/tmp/empty install`) fails, with errors like:

```
install: cannot create regular file '/tmp/empty/usr/share/man/man5/es/initscript.5': No such file or directory
```

This is because the rule to create the directories for translated man pages in `src/Makefile` is using the pattern `../man/po/??/` to find the list of languages, which doesn't match anything in the release tarball. This makes it match the .po files instead.