### PR TITLE
Don't built sulogin on Debian by default.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,8 +40,8 @@ endif
 
 ifeq ($(DISTRO),Debian)
 CPPFLAGS+= -DACCTON_OFF
-SBIN	+= sulogin bootlogd
-MAN8	+= sulogin.8 bootlogd.8
+SBIN	+= bootlogd
+MAN8	+= bootlogd.8
 MANDB	:=
 endif
 


### PR DESCRIPTION
It has been built by util-linux since Stretch, and as it was the only part we need libcrypt-dev for, rebootstrap folks would like this dependency gone.