### PR TITLE
Fix pidof symlink lookup

### DIFF
--- a/src/killall5.c
+++ b/src/killall5.c
@@ -729,7 +729,7 @@ PIDQ_HEAD *pidof(char *prog)
 	PIDQ_HEAD	*q;
 	char		*s;
 	int		nfs = 0;
-	int		dostat = 0;
+	int		pathlookup = 0;
 	int		foundone = 0;
 	int		ok = 0;
 	const int	root = (getuid() == 0);
@@ -738,11 +738,8 @@ PIDQ_HEAD *pidof(char *prog)
 	if (! prog)
 		return NULL;
 
-	/* Try to stat the executable. */
-	if ( (prog[0] == '/') && ( realpath(prog, real_path) ) ) {
-		memset(&real_path[0], 0, sizeof(real_path));
-		dostat++;
-	}
+	if ( (prog[0] == '/') && ( realpath(prog, real_path) ) )
+		pathlookup++;
 
 	/* Get basename of program. */
 	if ((s = strrchr(prog, '/')) == NULL)
@@ -756,8 +753,8 @@ PIDQ_HEAD *pidof(char *prog)
 	q = (PIDQ_HEAD *)xmalloc(sizeof(PIDQ_HEAD));
 	q = init_pid_q(q);
 
-	/* First try to find a match based on dev/ino pair. */
-	if (dostat) {
+	/* First try to find a match based on path. */
+	if (pathlookup) {
 		for (p = plist; p; p = p->next) {
 			if (p->pathname && strcmp(real_path, p->pathname) == 0) {
 				add_pid_to_q(q, p);


### PR DESCRIPTION
The following commit broke pidof's ability to follow symlinks:

commit 0b695c7e0b1cac60ed77c56f224e296f023b652e
Author: Jesse Smith <jsmith@resonatingmedia.com>
Date:   Thu Oct 21 14:44:55 2021 -0300

    Use readlink() instead of stat() to check processes. This shold avoid
    hanging if NFS mounts are not responding.

Example of broken behavior:
$ cd /tmp
$ ln -fs /usr/bin/top
$ ./top &
[1] 2438408

$ pidof top
2438408

$ pidof /usr/bin/top
2438408

$ pidof /tmp/top
$

With this fix pidof can now follow the symlink:
$ pidof /tmp/top
2438408