### PR TITLE
halt: call shutdown -h -H when should_poweroff is false

### DIFF
--- a/src/halt.c
+++ b/src/halt.c
@@ -162,8 +162,8 @@ void do_shutdown(char *fl, int should_poweroff, char *tm)
 
 	args[i++] = "shutdown";
 	args[i++] = fl;
-        if ( (! strcmp(fl, "-h") ) && (should_poweroff) )
-           args[i++] = "-P";
+        if (!strcmp(fl, "-h"))
+		args[i++] = (should_poweroff ? "-P" : "-H");
 	if (tm) {
 		args[i++] = "-t";
 		args[i++] = tm;


### PR DESCRIPTION
This results in more well-defined behavior for the halt command.

Calling 'halt' should result in a system halt without powering off.
halt -> shutdown -h -H -> INIT_HALT=HALT -> no power off

Calling 'halt -p' or 'poweroff' results in power off.
poweroff -> shutdown -h -P -> INIT_HALT=POWEROFF -> power off

Calling 'shutdown -h' without -H or -P results an unset INIT_HALT variable, which leaves the decision up to the distro init scripts.