### PR TITLE
hddown: include libgen.h for basename API

### DIFF
--- a/src/hddown.c
+++ b/src/hddown.c
@@ -24,6 +24,7 @@ char *v_hddown = "@(#)hddown.c  1.02  22-Apr-2003  miquels@cistron.nl";
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
musl has removed the non-prototype declaration of basename from string.h [1] which now results in build errors with clang-17+ compiler

include libgen.h for using the posix declaration of the funciton.

Fixes

hddown.c:135:8: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
  135 |                         ptr = basename(lnk);
      |                             ^ ~~~~~~~~~~~~~

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7