### PR TITLE
init: shutdown the system on SIGRTMIN+4

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -135,6 +135,13 @@ CHILD ch_emerg = {		/* Emergency shell */
 	NULL
 };
 
+CHILD ch_poweroff = {
+	.action = ONCE,
+	.id = "~~",
+	.rlevel = "S",
+	.process = "/sbin/shutdown -hP now"
+};
+
 char runlevel = 'S';		/* The current run level */
 char thislevel = 'S';		/* The current runlevel */
 char prevlevel = 'N';		/* Previous runlevel */
@@ -2717,6 +2724,12 @@ void process_signals()
 	DELSET(got_signals, SIGINT);
   }
 
+  if (ISMEMBER(got_signals, SIGRTMIN+4)) {
+	INITDBG(L_VB, "got SIGRTMIN+4");
+	startup(&ch_poweroff);
+	DELSET(got_signals, SIGRTMIN+4);
+  }
+
   if (ISMEMBER(got_signals, SIGWINCH)) {
 	INITDBG(L_VB, "got SIGWINCH");
 	/* Tell kbrequest entry to start up */
@@ -2858,6 +2871,7 @@ void init_main(void)
   SETSIG(sa, SIGTSTP,  stop_handler, SA_RESTART);
   SETSIG(sa, SIGCONT,  cont_handler, SA_RESTART);
   SETSIG(sa, SIGSEGV,  (void (*)(int))segv_handler, SA_RESTART);
+  SETSIG(sa, SIGRTMIN+4, signal_handler, 0);
 
   console_init();
 


### PR DESCRIPTION
This makes sysvinit behave nicely when it is running in a systemd-nspawn container. When the user executes "machinectl stop", systemd sends SIGRTMIN+4 to PID 1 in the container, and expects that to initiate a graceful shutdown (power-off).

The cleanest way to replicate this in sysvinit is to execute the shutdown command with appropriate options.