### PR TITLE
Include pty.h and sys/sysmacros.h on any GNU libc OS

### DIFF
--- a/src/bootlogd.c
+++ b/src/bootlogd.c
@@ -41,11 +41,11 @@
 #include <getopt.h>
 #include <dirent.h>
 #include <fcntl.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__GLIBC__)
 #include <pty.h>
 #endif
 
-#if defined (__linux__) || defined(__GNU__)
+#if defined (__linux__) || defined(__GLIBC__)
 #include <sys/sysmacros.h>
 #endif
 


### PR DESCRIPTION
They are provided by GNU libc, so include them when using that libc. This fixes the build on OSes other than Linux that use GNU libc.