### PR TITLE
Makefile: Make proper use of sysconfdir

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -9,6 +9,10 @@ sysvinit (3.12) unreleased; urgency=low
       space in place of the expected time stamp). We also no longer assume returned string
       is at least 11-16 characters.
 
+    * Re-commit flexible Makefile for GoboLinux.
+
+    * Make sure pty.h and sys/sysmacros.h are included when building bootlogd on
+      systems with glibc.
 
 
 sysvinit (3.11) released; urgency=low

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,3 +1,16 @@
+sysvinit (3.12) unreleased; urgency=low
+
+    * There were instances of the ctime() function being called in multiple files without
+      checking the return value (can be NULL) and without checking the length of the
+      returned information. While there _should_ never be a case where ctime() fails
+      assuming success and length of returned string isn't ideal (or future-proof).
+      We now check the return value of ctime() in bootlogd, dowall, last, logsave, and
+      shutdown. Where no valid value is returned we supply a dummy value (usually a
+      space in place of the expected time stamp). We also no longer assume returned string
+      is at least 11-16 characters.
+
+
+
 sysvinit (3.11) released; urgency=low
 
     * Some escape characters were included in the inittab manual page, but not displayed

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,8 +40,8 @@ endif
 
 ifeq ($(DISTRO),Debian)
 CPPFLAGS+= -DACCTON_OFF
-SBIN	+= bootlogd
-MAN8	+= bootlogd.8
+SBIN	+= sulogin bootlogd
+MAN8	+= sulogin.8 bootlogd.8
 MANDB	:=
 endif
 
@@ -65,9 +65,6 @@ BIN	+= mountpoint
 MAN1	+= mountpoint.1
 endif
 
-MANPAGES:=$(MAN1) $(MAN5) $(MAN8)
-MANPAGES+=$(subst ../man/,,$(foreach man,$(MANPAGES),$(wildcard ../man/??/$(man))))
-
 ID		= $(shell id -u)
 BIN_OWNER	= root
 BIN_GROUP	= root
@@ -80,7 +77,14 @@ else
   INSTALL_DATA	= install -m 644
 endif
 INSTALL_DIR	= install -m 755 -d
-MANDIR		= /usr/share/man
+
+ROOT         ?=
+base_bindir  ?= /bin
+base_sbindir ?= /sbin
+bindir       ?= /usr/bin
+sysconfdir   ?= /etc
+includedir   ?= /usr/include
+mandir       ?= /usr/share/man
 
 ifeq ($(WITH_SELINUX),yes)
   SELINUX_DEF	=  -DWITH_SELINUX
@@ -91,8 +95,6 @@ else
   INITLIBS	=
   SULOGINLIBS	=
 endif
-
-ROOT	?= $(DESTDIR)
 
 # Additional libs for GNU libc.
 ifneq ($(wildcard $(ROOT)/usr/lib*/libcrypt.*),)
@@ -196,34 +198,45 @@ clobber:	cleanobjs
 distclean:	clobber
 
 install:	all
-		$(INSTALL_DIR) $(ROOT)/bin/ $(ROOT)/sbin/
-		$(INSTALL_DIR) $(ROOT)/usr/bin/
+		$(INSTALL_DIR) $(ROOT)$(base_bindir)/ $(ROOT)$(base_sbindir)/
+		$(INSTALL_DIR) $(ROOT)$(bindir)/
 		for i in $(BIN); do \
-			$(INSTALL_EXEC) $$i $(ROOT)/bin/ ; \
+			$(INSTALL_EXEC) $$i $(ROOT)$(base_bindir)/ ; \
 		done
 		for i in $(SBIN); do \
-			$(INSTALL_EXEC) $$i $(ROOT)/sbin/ ; \
+			$(INSTALL_EXEC) $$i $(ROOT)$(base_sbindir)/ ; \
 		done
 		for i in $(USRBIN); do \
-			$(INSTALL_EXEC) $$i $(ROOT)/usr/bin/ ; \
+			$(INSTALL_EXEC) $$i $(ROOT)$(bindir)/ ; \
 		done
 		# $(INSTALL_DIR) $(ROOT)/etc/
 		$(INSTALL_DIR) $(ROOT)/etc/inittab.d
 		# $(INSTALL_EXEC) ../doc/initscript.sample $(ROOT)/etc/
-		ln -sf halt $(ROOT)/sbin/reboot
-		ln -sf halt $(ROOT)/sbin/poweroff
-		ln -sf init $(ROOT)/sbin/telinit
-		ln -sf ../sbin/killall5 $(ROOT)/bin/pidof
-		if [ ! -f $(ROOT)/usr/bin/lastb ]; then \
-			ln -sf last $(ROOT)/usr/bin/lastb; \
+		ln -sf halt $(ROOT)$(base_sbindir)/reboot
+		ln -sf halt $(ROOT)$(base_sbindir)/poweroff
+		ln -sf init $(ROOT)$(base_sbindir)/telinit
+		ln -sf $(base_sbindir)/killall5 $(ROOT)$(base_bindir)/pidof
+		if [ ! -f $(ROOT)$(bindir)/lastb ]; then \
+			ln -sf last $(ROOT)$(bindir)/lastb; \
 		fi
-		$(INSTALL_DIR) $(ROOT)/usr/include/
-		$(INSTALL_DATA) initreq.h $(ROOT)/usr/include/
-		for man in $(MANPAGES) ; do \
-		    targetdir=$(ROOT)$(MANDIR)/$$(dirname $$man)/man$${man##*.}; \
-		    $(INSTALL_DIR) $$targetdir; \
-		    $(INSTALL_DATA) ../man/$$man $$targetdir/$$(basename $$man); \
-		    sed -i "1{ $(MANDB); }" $$targetdir/$$(basename $$man); \
+		$(INSTALL_DIR) $(ROOT)$(includedir)/
+		$(INSTALL_DATA) initreq.h $(ROOT)$(includedir)/
+		for lang in  '' $(patsubst ../man/po/%.po,%,$(wildcard ../man/po/??.po)); do \
+			$(INSTALL_DIR) $(ROOT)$(mandir)/man1/$$lang; \
+			$(INSTALL_DIR) $(ROOT)$(mandir)/man5/$$lang; \
+			$(INSTALL_DIR) $(ROOT)$(mandir)/man8/$$lang; \
+		done
+		for man in $(MAN1) $(subst ../man/,,$(foreach man,$(MAN1),$(wildcard ../man/??/$(man)))); do \
+			$(INSTALL_DATA) ../man/$$man $(ROOT)$(mandir)/man1/$$man; \
+			sed -i "1{ $(MANDB); }" $(ROOT)$(mandir)/man1/$$man ; \
+		done
+		for man in $(MAN5) $(subst ../man/,,$(foreach man,$(MAN5),$(wildcard ../man/??/$(man)))); do \
+			$(INSTALL_DATA) ../man/$$man $(ROOT)$(mandir)/man5/$$man; \
+			sed -i "1{ $(MANDB); }" $(ROOT)$(mandir)/man5/$$man ; \
+		done
+		for man in $(MAN8) $(subst ../man/,,$(foreach man,$(MAN8),$(wildcard ../man/??/$(man)))); do \
+			$(INSTALL_DATA) ../man/$$man $(ROOT)$(mandir)/man8/$$man; \
+			sed -i "1{ $(MANDB); }" $(ROOT)$(mandir)/man8/$$man ; \
 		done
 ifeq ($(ROOT),)
 		#

--- a/src/Makefile
+++ b/src/Makefile
@@ -209,9 +209,9 @@ install:	all
 		for i in $(USRBIN); do \
 			$(INSTALL_EXEC) $$i $(ROOT)$(bindir)/ ; \
 		done
-		# $(INSTALL_DIR) $(ROOT)/etc/
-		$(INSTALL_DIR) $(ROOT)/etc/inittab.d
-		# $(INSTALL_EXEC) ../doc/initscript.sample $(ROOT)/etc/
+		# $(INSTALL_DIR) $(sysconfdir)/
+		$(INSTALL_DIR) $(sysconfdir)/inittab.d
+		# $(INSTALL_EXEC) ../doc/initscript.sample $(sysconfdir)/
 		ln -sf halt $(ROOT)$(base_sbindir)/reboot
 		ln -sf halt $(ROOT)$(base_sbindir)/poweroff
 		ln -sf init $(ROOT)$(base_sbindir)/telinit

--- a/src/bootlogd.c
+++ b/src/bootlogd.c
@@ -417,7 +417,9 @@ void writelog(FILE *fp, unsigned char *ptr, int len, int print_escape_characters
 			char *s;
 			time(&t);
 			s = ctime(&t);
-			fprintf(fp, "%.24s: ", s);
+			if (! s)
+                           s = " ";
+                        fprintf(fp, "%.24s: ", s);
 			dosync = 1;
 			first_run = 0;
 		}

--- a/src/bootlogd.c
+++ b/src/bootlogd.c
@@ -41,11 +41,8 @@
 #include <getopt.h>
 #include <dirent.h>
 #include <fcntl.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__GLIBC__)
 #include <pty.h>
-#endif
-
-#if defined (__linux__) || defined(__GNU__)
 #include <sys/sysmacros.h>
 #endif
 

--- a/src/dowall.c
+++ b/src/dowall.c
@@ -191,6 +191,8 @@ void wall(const char *text, int remote)
 	/* Get the time */
 	time(&t);
 	date = ctime(&t);
+        if (! date)
+           date = " ";
 	for(p = date; *p && *p != '\n'; p++)
 		;
 	*p = 0;

--- a/src/last.c
+++ b/src/last.c
@@ -278,7 +278,18 @@ char *getbtmp()
 char *showdate()
 {
 	char *s = ctime(&lastdate);
-	s[16] = 0;
+        char *p;
+
+	if (s)
+        {
+          /* s[16] = 0; */
+          /* make sure string ends with a NULL. Do not assume string is 16 characters long. */
+          for (p = s; *p && *p != '\n'; p++) 
+             ;
+          *p = '\0';
+        }
+        else
+          s = " ";
 	return s;
 }
 
@@ -371,6 +382,7 @@ int list(struct utmp *p, time_t t, int what)
 	char		utline[UT_LINESIZE+1];
 	char		domain[256];
 	char		*s, **walk;
+        char            *my_ctime;
 	int		mins, hours, days;
 	int		r, len;
 
@@ -401,13 +413,16 @@ int list(struct utmp *p, time_t t, int what)
 	 *	Calculate times
 	 */
 	tmp = (time_t)p->ut_time;
-	strncpy(logintime, ctime(&tmp), sizeof(logintime));
+        my_ctime = ctime(&tmp);
+        if (! my_ctime)
+           my_ctime = "             ";
+	strncpy(logintime, my_ctime, sizeof(logintime));
 	logintime[sizeof(logintime)-1] = 0; /* enforce null termination */
 	if (fulltime)
-		sprintf(logouttime, "- %s", ctime(&t));
+		sprintf(logouttime, "- %s", my_ctime);
 	else {
 		logintime[16] = 0;
-		sprintf(logouttime, "- %s", ctime(&t) + 11);
+		sprintf(logouttime, "- %s", my_ctime + 11);
 		logouttime[7] = 0;
 	}
 	secs = t - p->ut_time;
@@ -638,7 +653,7 @@ int main(int argc, char **argv)
   int lastb = 0;	/* Is this 'lastb' ? */
   int extended = 0;	/* Lots of info. */
   char *altufile = NULL;/* Alternate wtmp */
-
+  char *my_ctime;
   time_t until = 0;	/* at what time to stop parsing the file */
 
   progname = mybasename(argv[0]);
@@ -959,7 +974,10 @@ int main(int argc, char **argv)
 		down = 0;
 	}
   }
-  printf("\n%s begins %s", mybasename(ufile), ctime(&begintime));
+  my_ctime = ctime(&begintime);
+  if (! my_ctime)
+     my_ctime = " ";
+  printf("\n%s begins %s", mybasename(ufile), my_ctime);
 
   fclose(fp);
 

--- a/src/logsave.c
+++ b/src/logsave.c
@@ -257,6 +257,7 @@ int main(int argc, char **argv)
 {
 	int	c, pid, rc;
 	char	*outfn, **cpp;
+        char    *ctime_output;
 	int	openflags = O_CREAT|O_WRONLY|O_TRUNC;
 	int	send_flag = SEND_LOG;
 	int	do_stdin;
@@ -298,7 +299,10 @@ int main(int argc, char **argv)
 	}
 	send_output("\n", 0, send_flag);
 	t = time(0);
-	send_output(ctime(&t), 0, send_flag);
+        ctime_output = ctime(&t);
+        if (! ctime_output)
+           ctime_output = " ";
+	send_output(ctime_output, 0, send_flag);
 	send_output("\n", 0, send_flag);
 
 	if (do_stdin)
@@ -308,7 +312,10 @@ int main(int argc, char **argv)
 
 	send_output("\n", 0, send_flag);
 	t = time(0);
-	send_output(ctime(&t), 0, send_flag);
+        ctime_output = ctime(&t);
+        if (! ctime_output)
+           ctime_output = " ";
+	send_output(ctime_output, 0, send_flag);
 	send_output("----------------\n", 0, send_flag);
 
 	if (outbuf) {

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -259,12 +259,15 @@ void donologin(int min)
 {
 	FILE *fp;
 	time_t t;
+        char *ctime_output;
 
 	time(&t);
 	t += 60 * min;
-
+        ctime_output = ctime(&t);
+        if (! ctime_output)
+            ctime_output = "soon";
 	if ((fp = fopen(NOLOGIN, "w")) != NULL) {
-  		fprintf(fp, "\rThe system is going down on %s\r\n", ctime(&t));
+  		fprintf(fp, "\rThe system is going down on %s\r\n", ctime_output);
   		if (message[0]) fputs(message, fp);
   		fclose(fp);
 	}


### PR DESCRIPTION
This is a follow-up to #13 and recent commit 98582c8.

This patch ensures to make proper use of `sysconfdir` in `src/Makefile`.