### PR TITLE
Fix missing bracket in -lcrypt test

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,7 @@ ifneq ($(wildcard $(ROOT)/$(usrdir)/lib*/libcrypt.*),)
 endif
 
 # Additional libs for GNU libc / multiarch on Debian based systems.
-ifneq ($(wildcard $(ROOT)/$usrdir)/lib/*/libcrypt.*),)
+ifneq ($(wildcard $(ROOT)/$(usrdir)/lib/*/libcrypt.*),)
 ifneq ($(findstring -lcrypt, $(SULOGINLIBS)), -lcrypt)
   SULOGINLIBS	+= -lcrypt
 endif


### PR DESCRIPTION
This was a typo in 7b8ab85.