### PR TITLE
Align for 64-bit platform, struct `repl` reduced size from 24 to 16 bytes

### DIFF
--- a/src/fstab-decode.c
+++ b/src/fstab-decode.c
@@ -36,11 +36,11 @@ decode(char *s)
 			*dest = *src++;
 		else {
 			static const struct repl {
-				char orig[4];
 				size_t len;
+				char orig[4];
 				char new;
 			} repls[] = {
-#define R(X, Y) { X, sizeof(X) - 1, Y }
+#define R(X, Y) { sizeof(X) - 1, X, Y }
 				R("\\", '\\'),
 				R("011", '\t'),
 				R("012", '\n'),


### PR DESCRIPTION

@slicer69, hello again.

## About changes:

Smaller size structure or class, higher chance putting into CPU cache.

Most processors are already 64 bit, so the change won't make it any worse.

More info about: https://stackoverflow.com/a/20882083